### PR TITLE
Add Gmail permission check / scrape setting

### DIFF
--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -28,4 +28,10 @@ export default class User implements googleauth.Profile {
     //boolean variable to determine if the user deactivated the account
     @Column({ nullable: true })
     accountDeactivated?: boolean;
+
+    /**
+     * Determines whether AppTrack should scrape this user's email or not (set upon registration / and also in settings).
+     */
+    @Column({ default: false })
+    scrape?: boolean;
 }

--- a/backend/routes/user/user.ts
+++ b/backend/routes/user/user.ts
@@ -22,6 +22,10 @@ router.get('/refresh', GoogleAuth.getAuthMiddleware(), async function (req: any,
         res.send("Account was deactivated");
         return;
     }
+    else if (!req.user.scrape) {
+        res.redirect(`${process.env.APPTRACK_FRONTEND}/dashboard`);
+        return;
+    }
     let messages = await getEmails(new GmailClient(user), user.lastEmailRefreshTime);
     let newEvents: Event[] = [];
     for (let message of messages) {
@@ -54,8 +58,8 @@ router.get('/refresh', GoogleAuth.getAuthMiddleware(), async function (req: any,
     res.redirect(`${process.env.APPTRACK_FRONTEND}/dashboard`);
 });
 
-router.get('/info', async function (req: any, res) { 
-    if(req.user) {
+router.get('/info', async function (req: any, res) {
+    if (req.user) {
         var obj = {
             name: req.user.displayName,
             photos: req.user.photos,


### PR DESCRIPTION
If "scrape" setting is set to true in user object, their inbox will not be scraped (and the lastEmailRefreshTime will not be updated). The scrape setting is currently set on **every login**, depending on if the user granted the "gmail.readonly" scope or not.